### PR TITLE
Update README.md for remove obsolete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,12 @@ Supported Ubuntu releases:
 
 
 Installation:
--------------
+-------------      
 
-    $ source /etc/lsb-release
+    $ sudo wget "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x869689FE09306074" -O /etc/apt/trusted.gpg.d/phd-chromium.asc
 
-    $ echo "deb https://freeshell.de/phd/chromium/${DISTRIB_CODENAME} /" \
+    $ echo "deb [signed-by=/etc/apt/trusted.gpg.d/phd-chromium.asc] https://freeshell.de/phd/chromium/$(lsb_release -sc) /" \
       | sudo tee /etc/apt/sources.list.d/phd-chromium.list
-
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 869689FE09306074
 
     $ sudo apt-get update
 
@@ -34,7 +32,7 @@ Installation:
 Signing key renewal:
 --------------------
 
-    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 869689FE09306074
+    $ sudo wget "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x869689FE09306074" -O /etc/apt/trusted.gpg.d/phd-chromium.asc
 
 
 Repository:


### PR DESCRIPTION
the apt-key adv command is obsolete and should no longer be used

for the following reason the keys are stored in the file /etc/apt/trusted.gpg which is obsolete

the keys should now be placed in /etc/apt/trusted.gpg.d

also it is not used to load the file

/etc/lsb-release

may the lsb_release -sc command return the same result

also if you can make a chromium-widevine package

on your deposit it would be very useful

https://github.com/amidevous/chromium-widevine/

manual method

```
wget https://github.com/amidevous/chromium-widevine/archive/refs/heads/master.tar.gz -O master.tar.gz && \
tar -xvf master.tar.gz && rm -f master.tar.gz && \
cd chromium-widevine-master && \
sudo ./use-standalone-widevine.sh
```